### PR TITLE
Use Claypoole for npmap

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,6 +33,7 @@
      [org.clojure/math.numeric-tower "0.0.2"]
      [me.raynes/fs "1.4.3"]
      [com.google.guava/guava "15.0"]
+     [com.climate/claypoole "0.3"]
 
      ;; nrepl to launch a remote repl
      [org.clojure/tools.nrepl "0.2.3"]

--- a/src/io/mandoline/test/concurrency.clj
+++ b/src/io/mandoline/test/concurrency.clj
@@ -139,10 +139,7 @@
           writer (-> ds-writer db/on-last-version (db/add-version dds))
           _ (->> slabs
                  (partition 10)
-                 ;; FIX: We should be using utils/npmap, but it
-                 ;; doesn't compose well with the npmap calls lower in
-                 ;; this stack. For now, pmap works.
-                 (pmap
+                 (utils/npmap
                   #(with-open [f (db/variable-writer writer
                                                      :foo
                                                      {:wrappers []})]


### PR DESCRIPTION
I wrote the library Claypoole, which provides a better pmap than Clojure has natively. I also think it's nicer than the npmap function that was implemented here.
