### PR TITLE
Fix concurrency test

### DIFF
--- a/src/io/mandoline/test/concurrency.clj
+++ b/src/io/mandoline/test/concurrency.clj
@@ -139,7 +139,7 @@
           writer (-> ds-writer db/on-last-version (db/add-version dds))
           _ (->> slabs
                  (partition 10)
-                 (utils/npmap
+                 (pmap
                   #(with-open [f (db/variable-writer writer
                                                      :foo
                                                      {:wrappers []})]


### PR DESCRIPTION
The concurrency test was using Mandoline's internal threadpool and
causing contention for the threads, making the test block. This change
fixes that.
