### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.mandoline/mandoline-core "0.1.5"
+(defproject io.mandoline/mandoline-core "0.1.6"
   :description
     "Mandoline is a distributed store for multi-dimensional arrays"
   :license {:name "Apache License, version 2.0"


### PR DESCRIPTION
- Changed utils/npmap to claypoole's pmap in
  io.mandoline.backend.dynamodb-test/ddb-lots-of-overlaps
