### PR TITLE
Throw exception on null bytebuffer

### DIFF
--- a/src/io/mandoline/impl.clj
+++ b/src/io/mandoline/impl.clj
@@ -186,7 +186,10 @@
   "Coerces a byte-buffer to a new Array with given data type and shape."
   [^ByteBuffer byte-buffer ^DataType dtype shape]
   (locking byte-buffer
-    (let [p (.position byte-buffer)
+    (let [_ (when (nil? byte-buffer)
+              (throw (IllegalArgumentException.
+                       "Can't construct byte-buffer from null.")))
+          p (.position byte-buffer)
           r (.remaining byte-buffer)
           ; If the ByteBuffer is not perfectly aligned with its
           ; underlying byte[] storage, make a copy. This copy defends
@@ -201,10 +204,7 @@
                (let [dst (byte-array r)]
                  (.get byte-buffer dst)
                  (ByteBuffer/wrap dst))
-               (if (nil? byte-buffer)
-                 (throw (IllegalArgumentException.
-                          "Can't construct byte-buffer from null"))
-                 byte-buffer))
+               byte-buffer)
           array (Array/factory dtype (int-array shape) bb)]
       ; Resume original position
       (.position byte-buffer p)

--- a/src/io/mandoline/impl.clj
+++ b/src/io/mandoline/impl.clj
@@ -185,11 +185,11 @@
 (defn ^ucar.ma2.Array bytes-to-array
   "Coerces a byte-buffer to a new Array with given data type and shape."
   [^ByteBuffer byte-buffer ^DataType dtype shape]
+  (when (nil? byte-buffer)
+    (throw (IllegalArgumentException.
+             "Can't construct byte-buffer from null.")))
   (locking byte-buffer
-    (let [_ (when (nil? byte-buffer)
-              (throw (IllegalArgumentException.
-                       "Can't construct byte-buffer from null.")))
-          p (.position byte-buffer)
+    (let [p (.position byte-buffer)
           r (.remaining byte-buffer)
           ; If the ByteBuffer is not perfectly aligned with its
           ; underlying byte[] storage, make a copy. This copy defends

--- a/src/io/mandoline/impl.clj
+++ b/src/io/mandoline/impl.clj
@@ -201,7 +201,10 @@
                (let [dst (byte-array r)]
                  (.get byte-buffer dst)
                  (ByteBuffer/wrap dst))
-               byte-buffer)
+               (if (nil? byte-buffer)
+                 (throw (IllegalArgumentException.
+                          "Can't construct byte-buffer from null"))
+                 byte-buffer))
           array (Array/factory dtype (int-array shape) bb)]
       ; Resume original position
       (.position byte-buffer p)

--- a/test/io/mandoline/impl_test.clj
+++ b/test/io/mandoline/impl_test.clj
@@ -67,4 +67,6 @@
     (is (= 3 (.position byte-buffer))
         "bytes-to-array does not change the position of the original ByteBuffer")
     (is (= 19 (.limit byte-buffer))
-        "bytes-to-array does not change the limit of the original ByteBuffer")))
+        "bytes-to-array does not change the limit of the original ByteBuffer")
+    (is (thrown? IllegalArgumentException (impl/bytes-to-array nil data-type shape))
+        "bytes-to-array throws an IllegalArgumentException when passed null reference")))


### PR DESCRIPTION
This change causes mandoline to throw an IllegalArgumentException when `bytes-to-array` is passed a null reference.