### PR TITLE
Use an LRU cache

### DIFF
--- a/src/io/mandoline/impl/cache.clj
+++ b/src/io/mandoline/impl/cache.clj
@@ -82,7 +82,7 @@
 
   Chunks are only cached after a cache miss on read, not after writing."
   [cache-size]
-  (c/lu-cache-factory {} :threshold cache-size))
+  (c/lru-cache-factory {} :threshold cache-size))
 
 (deftype CachingChunkStore [next-store chunk-cache cache-size]
   proto/ChunkStore


### PR DESCRIPTION
We're seeing some DynamoDB throttling that is suggestive, but not conclusive, of cache issues. I think that LU caches have very bad failure modes, and I think an LRU cache would be a safer, healthier choice.