### PR TITLE
Add local read-through cache for Index

### DIFF
--- a/src/io/mandoline/impl.clj
+++ b/src/io/mandoline/impl.clj
@@ -132,8 +132,10 @@
   (if use-cache?
     [compressed-store/mk-compressed-store cache/mk-caching-chunk-store]
     [compressed-store/mk-compressed-store]))
-(def default-index-reader-wrappers
-  (constantly []))
+(defn default-index-reader-wrappers [& _]
+  (if use-cache?
+    [cache/mk-caching-index]
+    []))
 (defn default-store-writer-wrappers [& _]
   (if use-cache?
     [compressed-store/mk-compressed-store cache/mk-caching-chunk-store]

--- a/test/io/mandoline/impl/cache_test.clj
+++ b/test/io/mandoline/impl/cache_test.clj
@@ -1,0 +1,23 @@
+(ns io.mandoline.impl.cache-test
+  (:require
+    [clojure.test :refer :all]
+    [io.mandoline.backend.mem :as mem]
+    [io.mandoline.impl.protocol :as proto]
+    [io.mandoline.impl.cache :as cache]
+    [io.mandoline.test.utils :as utils]))
+
+(deftest unit-test
+    (let [sch (mem/mk-schema :foo)
+          name (utils/random-name)
+          _ (proto/create-dataset sch name)
+          conn (proto/connect sch name)
+          idx (proto/index conn :myvar {:version-id 1234} {})
+          cache-idx (cache/mk-caching-index idx {})]
+
+      ; Write to the backend directly
+      (is (proto/write-index idx [1 2 3] nil "myhash1"))
+      ; Test `read` with and without cache
+      (is (= "myhash1" (proto/chunk-at cache-idx [1 2 3])))
+      (is (= "myhash1" (proto/chunk-at idx [1 2 3])))
+
+      (proto/destroy-dataset sch name)))


### PR DESCRIPTION
This patch implements a read-through cache to decrease latency in
retrieving frequently accessed indices. Useful when making subsequent
requests using previously created `reader` object